### PR TITLE
Wire up Angular SSR/CS API to the C# API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Bin/
 obj/
 Obj/
 
+/.vs/AngularDemo

--- a/Angular.Demo.API/Controllers/WeatherForecastController.cs
+++ b/Angular.Demo.API/Controllers/WeatherForecastController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Angular.Demo.API.Controllers
 {
 	[ApiController]
-	[Route("[controller]")]
+	[Route("api/[controller]")]
 	public class WeatherForecastController : ControllerBase
 	{
 		private static readonly string[] Summaries = new[]

--- a/Angular.Demo.API/Program.cs
+++ b/Angular.Demo.API/Program.cs
@@ -2,6 +2,16 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
+// Enable CORS from our local node
+builder.Services.AddCors(options =>
+{
+	options.AddPolicy("AllowNodeLocalhost",
+		builder => builder.WithOrigins("http://localhost:4200")
+		.AllowAnyMethod()
+		.AllowAnyHeader()
+		.AllowCredentials());
+});
+
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
@@ -10,13 +20,14 @@ builder.Services.AddSwaggerGen();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
+app.UseCors("AllowNodeLocalhost");
 if (app.Environment.IsDevelopment())
 {
 	app.UseSwagger();
 	app.UseSwaggerUI();
 }
-
-app.UseHttpsRedirection();
+//Disable HttpsRedirection while we hook up everything
+//app.UseHttpsRedirection();
 
 app.UseAuthorization();
 

--- a/Angular.Demo.UI/angular.json
+++ b/Angular.Demo.UI/angular.json
@@ -139,7 +139,10 @@
               "serverTarget": "Angular.Demo.UI:server:production"
             }
           },
-          "defaultConfiguration": "development"
+          "defaultConfiguration": "development",
+          "options": {
+            "proxyConfig": "src/proxy.conf.js"
+          }
         },
         "prerender": {
           "builder": "@nguniversal/builders:prerender",

--- a/Angular.Demo.UI/src/app/app.component.ts
+++ b/Angular.Demo.UI/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Component } from '@angular/core';
+import { environment } from './../environments/environment';
 
 @Component({
   selector: 'app-root',
@@ -10,7 +11,8 @@ export class AppComponent {
   public forecasts?: WeatherForecast[];
 
   constructor(http: HttpClient) {
-    http.get<WeatherForecast[]>('/weatherforecast').subscribe(result => {
+    console.log('environment', environment);
+    http.get<WeatherForecast[]>(environment.apiUrl + '/weatherforecast').subscribe(result => {
       this.forecasts = result;
     }, error => console.error(error));
   }

--- a/Angular.Demo.UI/src/environments/environment.prod.ts
+++ b/Angular.Demo.UI/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  apiUrl: 'https://localhost/api'
 };

--- a/Angular.Demo.UI/src/environments/environment.ts
+++ b/Angular.Demo.UI/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  apiUrl: 'http://localhost:5180/api'
 };
 
 /*

--- a/Angular.Demo.UI/src/proxy.conf.js
+++ b/Angular.Demo.UI/src/proxy.conf.js
@@ -1,11 +1,10 @@
-const PROXY_CONFIG = [
-  {
-    context: [
-      "/weatherforecast",
-    ],
-    target: "https://localhost:5001",
-    secure: false
+const PROXY_CONFIG = {
+  "/api/*": {
+    "target": "http://localhost:5180",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true
   }
-]
+}
 
 module.exports = PROXY_CONFIG;


### PR DESCRIPTION
- **Configure Proxy for Angular API requests**
  - Align http route for API requests in [...API/Controllers/WeatherForecastController.cs](https://github.com/cbernth/AngularDemo/compare/main...004c?expand=1#diff-89c6283d3ee6b18f42a2b6ff316532a180495197b6ba01159d2ba859ba771fa3) w. best practices by prefixing route w. `api/` and thus make the API call distinguishable from other http requests.
  - Modify the angular proxy configuration file [...UI/src/proxy.conf.js](https://github.com/cbernth/AngularDemo/compare/main...004c?expand=1#diff-cc5a5b1f1c7617bef7353f587df3c3d8fc92ea59508e464dd9432c347232b270) to route all http requests starting with `/api/*` to the .NET API. The port number in the proxy can be found in the [...API/Properties/launchSettings.json](https://github.com/cbernth/AngularDemo/blob/main/Angular.Demo.API/Properties/launchSettings.json) file.
  ![004c-1](https://user-images.githubusercontent.com/32438452/167482286-ad4d4ff5-4382-4f07-9200-52b5ff61f53d.png)
  - Tell the angular project builder to use the proxy settings for SSR by adding a proxy configuration entry to [...UI/angular.json](https://github.com/cbernth/AngularDemo/compare/main...004c?expand=1#diff-2de3a4d1eaf34c449d060f55fdced83e8a5f39651ebd6fa27042f67963ad7f76) pointing to the above modified proxy.conf.js file 

- **Configure the Angular 'environment' w. API urls**
  - Add an `apiUrl` entry to [....UI/src/environments/environment.ts](https://github.com/cbernth/AngularDemo/compare/main...004c?expand=1#diff-17bdd7993d371b59d33c3bb886c338db6e277a6be80bc0ca2d185938cf3c9d77) and [...UI/src/environments/environment.prod.ts](https://github.com/cbernth/AngularDemo/compare/main...004c?expand=1#diff-d0cf935d8b3a80090549d3895c30b32474ab59f746181c921e34ea2ce2d94f4f). Please note that the port number is only applied in the default (non-production) settings.
  - Modify the [...UI/src/app/app.component.ts](https://github.com/cbernth/AngularDemo/compare/main...004c?expand=1#diff-8144c3f195d71ca63339d1aede21314f8e236cffac0d8eb0b9d5a79a5fb357bc) to import and use the `environment.apiUrl` entry in the http request.

- **Configure CORS in the .NET API**
  - Add CORS configuration to the [...API/Program.cs](https://github.com/cbernth/AngularDemo/compare/main...004c?expand=1#diff-4a25848be74304b1cc108e4116bf8aff22898d90063e9d496fb6383f39c67e08). Please note that we also comment out like this `//app.UseHttpsRedirection()`, to get the Angular SSR + Angular CS code running in development mode.
