### PR TITLE
Added strongly typed app settings for injection

### DIFF
--- a/Angular.Demo.API/Configuration/AppSettingsConfig.cs
+++ b/Angular.Demo.API/Configuration/AppSettingsConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace Angular.Demo.API
+{
+	public class AppSettingsConfig
+	{
+		public ConnectionStringsConfig? ConnectionStrings { get; set; }
+
+	}
+}

--- a/Angular.Demo.API/Configuration/ConnectionStringsConfig.cs
+++ b/Angular.Demo.API/Configuration/ConnectionStringsConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace Angular.Demo.API
+{
+	public class ConnectionStringsConfig
+	{
+		public string? webdbuser { get; set; }
+	
+	}
+}

--- a/Angular.Demo.API/Controllers/WeatherForecastController.cs
+++ b/Angular.Demo.API/Controllers/WeatherForecastController.cs
@@ -12,10 +12,12 @@ namespace Angular.Demo.API.Controllers
 		};
 
 		private readonly ILogger<WeatherForecastController> _logger;
+		private readonly AppSettingsConfig _appSettings;
 
-		public WeatherForecastController(ILogger<WeatherForecastController> logger)
+		public WeatherForecastController(ILogger<WeatherForecastController> logger, AppSettingsConfig appSettingsConfig)
 		{
 			_logger = logger;
+			_appSettings = appSettingsConfig;
 		}
 
 		[HttpGet(Name = "GetWeatherForecast")]

--- a/Angular.Demo.API/Program.cs
+++ b/Angular.Demo.API/Program.cs
@@ -1,7 +1,12 @@
+using Angular.Demo.API;
+using Microsoft.Extensions.Options;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
+builder.Services.Configure<AppSettingsConfig>(builder.Configuration);
+builder.Services.AddScoped(sp => sp.GetRequiredService<IOptionsSnapshot<AppSettingsConfig>>().Value);
 // Enable CORS from our local node
 builder.Services.AddCors(options =>
 {

--- a/Angular.Demo.API/appsettings.json
+++ b/Angular.Demo.API/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "webdbuser": "Data Source=Localhost;Initial Catalog=Test;User ID=test;Password=Testtest!1;Application Name=Angular.Demo.API;"
+  }
 }


### PR DESCRIPTION
Added two initial configuration classes `...API/Configuration/AppSettingsConfig.cs` and `...API/Configuration/ConnectionStringsConfig.cs` to reflect (some of) the entries in appsettings.json to enable injection of strongly typed configuration into controllers.