### PR TITLE
Adding ApiControllerBase to define shared properties of the API

### DIFF
--- a/Angular.Demo.API/Controllers/Base/ApiControllerBase.cs
+++ b/Angular.Demo.API/Controllers/Base/ApiControllerBase.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Angular.Demo.API.Controllers
+{
+	[ApiController]
+	[Route("api/[controller]/[action]")]
+	[Produces("application/json")]
+	public class ApiControllerBase : ControllerBase
+	{ }
+
+}

--- a/Angular.Demo.API/Controllers/WeatherForecastController.cs
+++ b/Angular.Demo.API/Controllers/WeatherForecastController.cs
@@ -2,9 +2,8 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Angular.Demo.API.Controllers
 {
-	[ApiController]
-	[Route("api/[controller]")]
-	public class WeatherForecastController : ControllerBase
+
+	public class WeatherForecastController : ApiControllerBase
 	{
 		private static readonly string[] Summaries = new[]
 		{
@@ -20,7 +19,7 @@ namespace Angular.Demo.API.Controllers
 			_appSettings = appSettingsConfig;
 		}
 
-		[HttpGet(Name = "GetWeatherForecast")]
+		[HttpGet]
 		public IEnumerable<WeatherForecast> Get()
 		{
 			return Enumerable.Range(1, 5).Select(index => new WeatherForecast

--- a/Angular.Demo.UI/src/app/app.component.ts
+++ b/Angular.Demo.UI/src/app/app.component.ts
@@ -12,7 +12,7 @@ export class AppComponent {
 
   constructor(http: HttpClient) {
     console.log('environment', environment);
-    http.get<WeatherForecast[]>(environment.apiUrl + '/weatherforecast').subscribe(result => {
+    http.get<WeatherForecast[]>(environment.apiUrl + '/WeatherForecast/Get').subscribe(result => {
       this.forecasts = result;
     }, error => console.error(error));
   }


### PR DESCRIPTION
By defining a controller base class we that's inherited from other controllers, we can easily configure all API endpoints in a single place, making it easier to adhere to the same pattern.